### PR TITLE
[change] Fixed ignore errors for celery

### DIFF
--- a/ow_sentry_utils/__init__.py
+++ b/ow_sentry_utils/__init__.py
@@ -19,7 +19,7 @@ SENTRY_IGNORE_ERRORS = {
         (
             r'Process (?:\'|\")ForkPoolWorker-([\d.]+)(?:\'|\") pid:([\d.]+)'
             r' exited with (?:\'|\")signal 15 \(SIGTERM\)(?:\'|\")'
-        )
+        ),
     ],
     'celery.concurrency.asynpool': [r'Timed out waiting for UP message from '],
     # Daphne throws below error when we restart the service using
@@ -43,10 +43,17 @@ def before_send(event, hint):
     event_logger = event.get('logger', None)
     if event_logger not in SENTRY_IGNORE_ERRORS.keys():
         return event
+    # Sentry event contains error message and paramenters
+    # required for formatting the error message if the
+    # error message contains placeholders.
+    # E.g. error_message "Worker exited prematurely: exitcode %d"
+    # with error_params "[15]"".
     error_message = event.get('logentry', {}).get('message', '')
     error_params = event.get('logentry', {}).get('params', [])
-    print(error_message % tuple(error_params))
-    for error in SENTRY_IGNORE_ERRORS[event_logger]:
-        if re.search(error, error_message % tuple(error_params)):
+    for ignore_error in SENTRY_IGNORE_ERRORS[event_logger]:
+        # Substitute the placeholders in error_message with their
+        # corressponding value in error_params before searching
+        # for ignore_error regular expression.
+        if re.search(ignore_error, error_message % tuple(error_params)):
             return None
     return event


### PR DESCRIPTION
"before_send" method was comparing error messages with placeholder
in them which led to some errors bypassing the checks.

Fixed this by formating the error message before checking.