### PR TITLE
[fix] Fixed traces_sampler using list in startswith

### DIFF
--- a/ow_sentry_utils/__init__.py
+++ b/ow_sentry_utils/__init__.py
@@ -33,7 +33,7 @@ def traces_sampler(context):
     if context['transaction_context']['op'] == 'celery.task':
         return 0.0
     if context.get('asgi_scope') and context['asgi_scope']['path'].startswith(
-        ['/controller/checksum/', '/api/v1/monitoring/device/']
+        ('/controller/checksum/', '/api/v1/monitoring/device/')
     ):
         return 0.0001
     return 0.001


### PR DESCRIPTION
"str.startswith" supports using tuple in the first argument.
The tuple can contain multiple prefixes against which the
string will be compared.

Earlier, a list was used instead of tuple.